### PR TITLE
Intern object keys as well as values.

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -6,6 +6,39 @@ var mapTag = "[object Map]";
 
 var arson = require("./index.js");
 
+function isPlainObject(value) {
+  var isObject = value && typeof value === "object";
+  if (isObject) {
+    var proto = Object.getPrototypeOf
+      ? Object.getPrototypeOf(value)
+      : value.__proto__;
+    return proto === Object.prototype;
+  }
+  return false;
+}
+
+arson.registerType("o", {
+  deconstruct: function (obj, tolerant) {
+    if (tolerant || isPlainObject(obj)) {
+      var props = [];
+      Object.keys(obj).forEach(function (key) {
+        props.push(key, obj[key]);
+      });
+      return props;
+    }
+  },
+
+  reconstruct: function (props) {
+    if (props) {
+      for (var i = 0; i < props.length; i += 2) {
+        this[props[i]] = props[i + 1];
+      }
+    } else {
+      return {};
+    }
+  }
+});
+
 typeof Buffer === "function" &&
 typeof Buffer.isBuffer === "function" &&
 arson.registerType("Buffer", {


### PR DESCRIPTION
Instead of encoding objects as object literals with (possibly repeated) string keys, this commit encodes them as an array of (interned) keys and values:
```js
> ARSON.encode([{lonnngKeyName:"a",a:true},{b:false,lonnngKeyName:"b"}])
'[[1,2],["o",3,4,4,5],["o",6,7,3,6],"lonnngKeyName","a",true,"b",false]'
> ARSON.decode(_)
[ { lonnngKeyName: 'a', a: true },
  { b: false, lonnngKeyName: 'b' } ]
```
Notice that the key string `"lonnngKeyName"` appears only once in the encoding.

Here's the output without this change applied:
```js
> ARSON.encode([{lonnngKeyName:"a",a:true},{b:false,lonnngKeyName:"b"}])
'[[1,2],{"lonnngKeyName":3,"a":4},{"b":5,"lonnngKeyName":6},"a",true,false,"b"]'
> ARSON.decode(_)
[ { lonnngKeyName: 'a', a: true },
  { b: false, lonnngKeyName: 'b' } ]
```